### PR TITLE
Add configurable Discourse URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ A simple Discord bot that searches the [GL.iNet forum](https://forum.gl-inet.com
 
 1. Create a Discord bot token and invite the bot to your server.
 2. Set the `DISCORD_TOKEN` environment variable to your bot token.
-3. Start the bot using Docker:
+3. Optionally set `DISCOURSE_BASE_URL` to the base URL of the Discourse
+   forum you want to search (defaults to `https://forum.gl-inet.com`).
+4. Start the bot using Docker:
 
 ```bash
 docker build -t discord-discourse .
-docker run -e DISCORD_TOKEN=YOUR_TOKEN discord-discourse
+docker run -e DISCORD_TOKEN=YOUR_TOKEN \
+           -e DISCOURSE_BASE_URL=https://forum.gl-inet.com \
+           discord-discourse
 ```
 
 In Discord, use:

--- a/bot.py
+++ b/bot.py
@@ -9,11 +9,12 @@ intents = discord.Intents.default()
 
 bot = commands.Bot(command_prefix='!', intents=intents)
 
-SEARCH_URL = 'https://forum.gl-inet.com/search.json'
+BASE_URL = os.getenv("DISCOURSE_BASE_URL", "https://forum.gl-inet.com").rstrip("/")
+SEARCH_URL = f"{BASE_URL}/search.json"
 
 @bot.command(name='search')
 async def search(ctx, *, query: str):
-    """Search the GL.iNet forum and return top 5 results."""
+    """Search the configured Discourse forum and return top 5 results."""
     params = {'q': query}
     try:
         r = requests.get(SEARCH_URL, params=params)
@@ -29,7 +30,7 @@ async def search(ctx, *, query: str):
         title = topic.get('title')
         slug = topic.get('slug')
         id_ = topic.get('id')
-        url = f'https://forum.gl-inet.com/t/{slug}/{id_}'
+        url = f"{BASE_URL}/t/{slug}/{id_}"
         results.append(f'{title} - {url}')
 
     if results:


### PR DESCRIPTION
## Summary
- allow setting `DISCOURSE_BASE_URL` to search any Discourse-powered forum
- document the new environment variable

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686d617191408323ba6f4262cde1042a