### PR TITLE
Add workflow to publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Build and publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade build
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Publish to GitHub Packages
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          repository-url: https://pypi.pkg.github.com/${{ github.repository_owner }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "discord-discourse"
+version = "0.1.0"
+description = "A Discord bot that searches a Discourse forum"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+authors = [{name = "WickedYoda"}]
+dependencies = [
+    "discord.py==2.3.2",
+    "requests"
+]
+
+[tool.setuptools]
+py-modules = ["bot"]


### PR DESCRIPTION
## Summary
- add pyproject.toml to build a Python package
- add GitHub Actions workflow to build and publish to GitHub Packages on push to main or manual run

## Testing
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_686d8b5b632c832388443d2cde00a4d2