### PR TITLE
Update workflow to use correct pypi-publish tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           python -m build
 
       - name: Publish to GitHub Packages
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow for publishing

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686d9577b1448323bab21acd0a2952d5