### PR TITLE
Fix GitHub Packages upload endpoint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           user: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          repository-url: https://pypi.pkg.github.com/${{ github.repository_owner }}
+          repository-url: https://upload.pypi.pkg.github.com/${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- fix publish URL for GitHub Packages

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686d9b8836a883239a15e27a77866b06