### PR TITLE
Improve token check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A simple Discord bot that searches the [GL.iNet forum](https://forum.gl-inet.com
 ## Usage
 
 1. Create a Discord bot token and invite the bot to your server.
-2. Set the `DISCORD_TOKEN` environment variable to your bot token.
+2. Set the `DISCORD_TOKEN` environment variable to your bot token. The bot
+   requires the Message Content intent to be enabled in the Discord developer
+   portal.
 3. Optionally set `DISCOURSE_BASE_URL` to the base URL of the Discourse
    forum you want to search (defaults to `https://forum.gl-inet.com`).
 4. Start the bot using Docker:

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,11 @@ from discord.ext import commands
 
 TOKEN = os.getenv('DISCORD_TOKEN')
 
+if not TOKEN:
+    raise RuntimeError("DISCORD_TOKEN environment variable not set")
+
 intents = discord.Intents.default()
+intents.message_content = True
 
 bot = commands.Bot(command_prefix='!', intents=intents)
 


### PR DESCRIPTION
## Summary
- fail fast if DISCORD_TOKEN is unset
- enable message content intent
- update README with intent requirement
- bump Docker base image to python:3.12-slim

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686da9834410832392c770409f2e8e8c